### PR TITLE
Only generate demos the brand supports

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -1,0 +1,12 @@
+{
+    "description": "A GitHub action to visually test Origami Components with Percy.",
+    "origamiType": null,
+    "origamiVersion": 1,
+    "keywords": [],
+    "support": "https://github.com/Financial-Times/origami-percy/issues",
+    "supportStatus": "maintained",
+    "supportContact": {
+        "email": "origami.support@ft.com",
+        "slack": "financialtimes/origami-support"
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ async function generateDemosFor(brand, demosConfig) {
   );
   const demoNames = brandSupportedDemos.map(d => d.name).join(',');
   await exec.exec(
-    `"${npxPath}" origami-build-tools demo --brand=${brand} --demo--filter="${demoNames}"`,
+    `"${npxPath}" origami-build-tools demo --brand=${brand} --demo-filter="${demoNames}"`,
     [],
     { cwd: "./" }
   );

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const { context, GitHub } = require("@actions/github");
       const componentConfig = JSON.parse(
         fs.readFileSync("./origami.json", "utf-8")
       );
+      const demosConfig = componentConfig.demos || [];
 
       let npxPath = await io.which("npx", true);
       await exec.exec(`"${npxPath}" origami-build-tools install`, [], {
@@ -32,10 +33,10 @@ const { context, GitHub } = require("@actions/github");
       });
       if (componentConfig.brands) {
         for (const brand of componentConfig.brands) {
-          await generateDemosFor(brand);
+          await generateDemosFor(brand, demosConfig);
         }
       } else {
-        await generateDemosFor("master");
+        await generateDemosFor("master", demosConfig);
       }
       await generatePercySnapshots();
 
@@ -62,11 +63,15 @@ const { context, GitHub } = require("@actions/github");
   }
 })();
 
-async function generateDemosFor(brand) {
+async function generateDemosFor(brand, demosConfig) {
   let npxPath = await io.which("npx", true);
   let outputDir = `demos/percy/${brand}`;
+  const brandSupportedDemos = demosConfig.filter(
+    d => !Array.isArray(d.brands) || d.brands.includes(brand)
+  );
+  const demoNames = brandSupportedDemos.map(d => d.name).join(',');
   await exec.exec(
-    `"${npxPath}" origami-build-tools demo --brand=${brand}`,
+    `"${npxPath}" origami-build-tools demo --brand=${brand} --demo--filter="${demoNames}"`,
     [],
     { cwd: "./" }
   );


### PR DESCRIPTION
For example, the o-colors contrast checker "demo" does not support the whitelabel brand.
<img width="632" alt="Screenshot 2020-05-28 at 10 57 38" src="https://user-images.githubusercontent.com/10405691/83128633-982f4600-a0d3-11ea-9a27-9b11572e09a4.png">


(also adds an origami.json)