### PR TITLE
Specify the version of origami build tools to use

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const { context, GitHub } = require("@actions/github");
       const demosConfig = componentConfig.demos || [];
 
       let npxPath = await io.which("npx", true);
-      await exec.exec(`"${npxPath}" origami-build-tools install`, [], {
+      await exec.exec(`"${npxPath}" origami-build-tools@^10.8.8 install`, [], {
         cwd: "./",
       });
       if (componentConfig.brands) {
@@ -37,7 +37,7 @@ const { context, GitHub } = require("@actions/github");
       } else {
         await generateDemosFor("master", demosConfig);
       }
-      
+
       await generatePercySnapshots();
 
       if (isPullRequestLabelledWithPercy) {
@@ -81,7 +81,7 @@ async function generateDemosFor(brand, demosConfig) {
   );
   const demoNames = brandSupportedDemos.map(d => d.name).join(',');
   await exec.exec(
-    `"${npxPath}" origami-build-tools demo --brand=${brand} --demo-filter="${demoNames}"`,
+    `"${npxPath}" origami-build-tools@^10.8.8 demo --brand=${brand} --demo-filter="${demoNames}"`,
     [],
     { cwd: "./" }
   );


### PR DESCRIPTION
Percy runs are currently failing because `origami-build-tools` is being used without a version specified. Therefore the latest major beta release is being used.
https://github.com/Financial-Times/o-topper/runs/1741365728?check_suite_focus=true

Related issue to specify version in package.json:
https://github.com/Financial-Times/origami-percy/issues/37