### PR TITLE
Run percy on all pull-requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,15 +5,11 @@ const fs = require("fs");
 const { context, GitHub } = require("@actions/github");
 
 (async () => {
-  const isPullRequestLabelledWithPercy =
-      context.payload.pull_request &&
-      context.payload.pull_request.labels
-        .map((label) => label.name)
-        .includes("percy");
+  const isPullRequest = context.payload.pull_request;
   try {
     const isMasterBranch = context.ref.endsWith("/master");
-    if (isMasterBranch || isPullRequestLabelledWithPercy) {
-      if (isPullRequestLabelledWithPercy) {
+    if (isMasterBranch || isPullRequest) {
+      if (isPullRequest) {
         core.exportVariable(
           "PERCY_PULL_REQUEST",
           String(context.payload.pull_request.number)
@@ -40,7 +36,7 @@ const { context, GitHub } = require("@actions/github");
 
       await generatePercySnapshots();
 
-      if (isPullRequestLabelledWithPercy) {
+      if (isPullRequest) {
         const token = core.getInput("github-token", { required: true });
         const github = new GitHub(token);
         await github.issues.createComment({
@@ -59,7 +55,7 @@ const { context, GitHub } = require("@actions/github");
       }
     }
   } catch (error) {
-    if (isPullRequestLabelledWithPercy) {
+    if (isPullRequest) {
       const token = core.getInput("github-token", { required: true });
       const github = new GitHub(token);
       await github.issues.createComment({


### PR DESCRIPTION
This changes the action to no longer run when a 'percy' label is added to a pull-request and instead to run on all pull-requests.

The reason we had the label trigger the action was because we had a very small allowance of percy runs available and we wanted to only run percy when we thought we needed to.

We now have a much higher allowance of percy runs, enough to be able to run the action on all pull-requests. This will remove the need for someone to remember to add a percy label to a pull-request which changes the ui.