### PR TITLE
only attempt to move the demos if they exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,8 +55,10 @@ async function generateDemosFor(brand, demosConfig) {
     [],
     { cwd: "./" }
   );
-  await io.mkdirP(outputDir);
-  await io.mv("demos/local", outputDir);
+  if (fs.existsSync("demos/local")) {
+    await io.mkdirP(outputDir);
+    await io.mv("demos/local", outputDir);
+  }
 }
 
 async function generatePercySnapshots() {


### PR DESCRIPTION
a component can support a brand whilst providing no demos for the brand. In that scenario, this action currently throws an ENOENT error like this:
>Error: ENOENT: no such file or directory, rename 'demos/local' -> 'demos/percy/whitelabel/local'

This commit changes the code to only move the folder if it exists, which fixes the issue.